### PR TITLE
Updated new sif file, removed --writable-tmpfs to avoid errors

### DIFF
--- a/amdihapps/chroma1gpu.sbatch
+++ b/amdihapps/chroma1gpu.sbatch
@@ -62,4 +62,9 @@ module load rocm-5.4.2/ucx-1.13.1/ompi/4.1.4
 tmp=/tmp/$USER/tmp-$$
 mkdir -p $tmp
 
-singularity run --pwd /benchmark --writable-tmpfs /shared/apps/bin/chroma_3.43.0-20211118.sif run-benchmark --ngpus 1
+# Copy the benchmark data to avoid using --writable-tmpfs
+singularity run /shared/apps/bin/chroma_3.43.0_29.sif cp -r /benchmark $tmp
+singularity run --bind $tmp/benchmark:/benchmark --pwd /benchmark /shared/apps/bin/chroma_3.43.0_29.sif run-benchmark --ngpus 1
+
+# Cleanup the benchmark data which was copied
+rm -rf $tmp

--- a/amdihapps/chroma2gpu.sbatch
+++ b/amdihapps/chroma2gpu.sbatch
@@ -63,4 +63,9 @@ module load rocm-5.4.2/ucx-1.13.1/ompi/4.1.4
 tmp=/tmp/$USER/tmp-$$
 mkdir -p $tmp
 
-singularity run --pwd /benchmark --writable-tmpfs /shared/apps/bin/chroma_3.43.0-20211118.sif run-benchmark --ngpus 2
+# Copy the benchmark data to avoid using --writable-tmpfs
+singularity run /shared/apps/bin/chroma_3.43.0_29.sif cp -r /benchmark $tmp
+singularity run --bind $tmp/benchmark:/benchmark --pwd /benchmark /shared/apps/bin/chroma_3.43.0_29.sif run-benchmark --ngpus 2
+
+# Cleanup the benchmark data which was copied
+rm -rf $tmp

--- a/amdihapps/chroma4gpu.sbatch
+++ b/amdihapps/chroma4gpu.sbatch
@@ -63,4 +63,9 @@ module load rocm-5.4.2/ucx-1.13.1/ompi/4.1.4
 tmp=/tmp/$USER/tmp-$$
 mkdir -p $tmp
 
-singularity run --pwd /benchmark --writable-tmpfs /shared/apps/bin/chroma_3.43.0-20211118.sif run-benchmark --ngpus 4
+# Copy the benchmark data to avoid using --writable-tmpfs
+singularity run /shared/apps/bin/chroma_3.43.0_29.sif cp -r /benchmark $tmp
+singularity run --bind $tmp/benchmark:/benchmark --pwd /benchmark /shared/apps/bin/chroma_3.43.0_29.sif run-benchmark --ngpus 4
+
+# Cleanup the benchmark data which was copied
+rm -rf $tmp

--- a/amdihapps/chroma8gpu.sbatch
+++ b/amdihapps/chroma8gpu.sbatch
@@ -63,4 +63,9 @@ module load rocm-5.4.2/ucx-1.13.1/ompi/4.1.4
 tmp=/tmp/$USER/tmp-$$
 mkdir -p $tmp
 
-singularity run --pwd /benchmark --writable-tmpfs /shared/apps/bin/chroma_3.43.0-20211118.sif run-benchmark --ngpus 8
+# Copy the benchmark data to avoid using --writable-tmpfs
+singularity run /shared/apps/bin/chroma_3.43.0_29.sif cp -r /benchmark $tmp
+singularity run --bind $tmp/benchmark:/benchmark --pwd /benchmark /shared/apps/bin/chroma_3.43.0_29.sif run-benchmark --ngpus 8
+
+# Cleanup the benchmark data which was copied
+rm -rf $tmp


### PR DESCRIPTION
Removed --writable-tmpfs as it was giving error - copied benchmark data locally on the system and ran tests.

satripat@smc-r08-04:~/sifs$ more ../chroma/chroma1gpu.sbatch-smc-r08-04-10647.err

**WARNING: Disabling --writable-tmpfs as it can't be used in conjunction with underlay
Error opening write file = ./XMLDAT
QMP m0,n1@node error: abort: 1**
